### PR TITLE
feat(types)!: change EndPoint to struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ aliyun OSS 的一个异步/同步客户端，包含以下功能：
 
 [![Coverage Status](https://coveralls.io/repos/github/tu6ge/oss-rs/badge.svg?branch=master)](https://coveralls.io/github/tu6ge/oss-rs?branch=master) [![Test and Publish](https://github.com/tu6ge/oss-rs/actions/workflows/publish.yml/badge.svg)](https://github.com/tu6ge/oss-rs/actions/workflows/publish.yml)
 
+> 现在的破坏性更新，都是为了 1.0 版本能够稳定
+
 ## 使用方法
 
 [查看文档](https://docs.rs/aliyun-oss-client/)

--- a/src/bucket/test.rs
+++ b/src/bucket/test.rs
@@ -192,7 +192,7 @@ async fn test_get_bucket_info() {
     //println!("{:?}", res);
     assert_eq!(
         format!("{:?}", res),
-        r#"Ok(Bucket { base: BucketBase { endpoint: CnShanghai, name: BucketName("barname") }, creation_date: 2016-11-05T13:10:10Z, storage_class: Standard })"#
+        r#"Ok(Bucket { base: BucketBase { endpoint: EndPoint { kind: CnShanghai, is_internal: false }, name: BucketName("barname") }, creation_date: 2016-11-05T13:10:10Z, storage_class: Standard })"#
     );
 }
 

--- a/src/bucket/test.rs
+++ b/src/bucket/test.rs
@@ -276,7 +276,7 @@ fn test_get_blocking_bucket_info() {
     //println!("{:?}", res);
     assert_eq!(
         format!("{:?}", res),
-        r#"Ok(Bucket { base: BucketBase { endpoint: CnShanghai, name: BucketName("barname") }, creation_date: 2016-11-05T13:10:10Z, storage_class: Standard })"#
+        r#"Ok(Bucket { base: BucketBase { endpoint: EndPoint { kind: CnShanghai, is_internal: false }, name: BucketName("barname") }, creation_date: 2016-11-05T13:10:10Z, storage_class: Standard })"#
     );
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,20 +225,6 @@ impl FromStr for BucketBase {
     /// assert_eq!(bucket.name(), "abc");
     /// assert_eq!(bucket.endpoint(), EndPoint::CnShanghai);
     ///
-    /// let bucket: BucketBase = "abc.oss-cn-jinan.aliyuncs.com".parse().unwrap();
-    /// assert_eq!(bucket.name(), "abc");
-    /// assert_eq!(
-    ///     bucket.endpoint(),
-    ///     EndPoint::Other(Cow::Borrowed("cn-jinan"))
-    /// );
-    ///
-    /// let bucket: BucketBase = "abc.oss-cn-jinan".parse().unwrap();
-    /// assert_eq!(bucket.name(), "abc");
-    /// assert_eq!(
-    ///     bucket.endpoint(),
-    ///     EndPoint::Other(Cow::Borrowed("cn-jinan"))
-    /// );
-    ///
     /// assert!("abc*#!".parse::<BucketBase>().is_err());
     /// assert!("abc".parse::<BucketBase>().is_err());
     /// ```
@@ -580,6 +566,10 @@ impl PartialEq<Url> for BucketBase {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
+    use crate::types::EndPointKind;
+
     use super::*;
 
     #[test]
@@ -755,6 +745,26 @@ mod tests {
                 ..
             }
         ));
+
+        let bucket: BucketBase = "abc.oss-cn-jinan.aliyuncs.com".parse().unwrap();
+        assert_eq!(bucket.name(), "abc");
+        assert_eq!(
+            bucket.endpoint(),
+            EndPoint {
+                kind: EndPointKind::Other(Cow::Borrowed("cn-jinan")),
+                is_internal: false,
+            }
+        );
+
+        let bucket: BucketBase = "abc.oss-cn-jinan".parse().unwrap();
+        assert_eq!(bucket.name(), "abc");
+        assert_eq!(
+            bucket.endpoint(),
+            EndPoint {
+                kind: EndPointKind::Other(Cow::Borrowed("cn-jinan")),
+                is_internal: false,
+            }
+        );
     }
 
     #[test]

--- a/src/object/test.rs
+++ b/src/object/test.rs
@@ -38,7 +38,7 @@ mod tests {
         let object_list = init_object_list(Some(String::from("foo3")), vec![]);
         assert_eq!(
             format!("{object_list:?}"),
-            "ObjectList { bucket: BucketBase { endpoint: CnShanghai, name: BucketName(\"abc\") }, prefix: Some(ObjectDir(\"foo2/\")), max_keys: 100, key_count: 200, next_continuation_token: \"foo3\", common_prefixes: [], search_query: Query { inner: {Custom(\"key1\"): InnerQueryValue(\"value1\")} } }"
+            "ObjectList { bucket: BucketBase { endpoint: EndPoint { kind: CnShanghai, is_internal: false }, name: BucketName(\"abc\") }, prefix: Some(ObjectDir(\"foo2/\")), max_keys: 100, key_count: 200, next_continuation_token: \"foo3\", common_prefixes: [], search_query: Query { inner: {Custom(\"key1\"): InnerQueryValue(\"value1\")} } }"
         );
     }
 

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -1,3 +1,5 @@
+use std::env::{remove_var, set_var};
+
 use http::header::CONTENT_TYPE;
 use http::{HeaderValue, Method};
 
@@ -10,7 +12,7 @@ fn test_get_bucket_url() {
     let client = Client::<ClientWithMiddleware>::new(
         "foo1".into(),
         "foo2".into(),
-        EndPoint::CnQingdao,
+        EndPoint::CN_QINGDAO,
         "foo4".parse().unwrap(),
     );
     let url = client.get_bucket_url();
@@ -18,11 +20,60 @@ fn test_get_bucket_url() {
 }
 
 #[test]
+fn test_from_env() {
+    set_var("ALIYUN_KEY_ID", "foo1");
+    set_var("ALIYUN_KEY_SECRET", "foo2");
+    set_var("ALIYUN_ENDPOINT", "qingdao");
+    set_var("ALIYUN_BUCKET", "foo4");
+    remove_var("ALIYUN_OSS_INTERNAL");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(url.as_str(), "https://foo4.oss-cn-qingdao.aliyuncs.com/");
+
+    set_var("ALIYUN_OSS_INTERNAL", "true");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(
+        url.as_str(),
+        "https://foo4.oss-cn-qingdao-internal.aliyuncs.com/"
+    );
+
+    set_var("ALIYUN_OSS_INTERNAL", "foo4");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(url.as_str(), "https://foo4.oss-cn-qingdao.aliyuncs.com/");
+
+    set_var("ALIYUN_OSS_INTERNAL", "1");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(
+        url.as_str(),
+        "https://foo4.oss-cn-qingdao-internal.aliyuncs.com/"
+    );
+
+    set_var("ALIYUN_OSS_INTERNAL", "yes");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(
+        url.as_str(),
+        "https://foo4.oss-cn-qingdao-internal.aliyuncs.com/"
+    );
+
+    set_var("ALIYUN_OSS_INTERNAL", "Y");
+    let client = Client::<ClientWithMiddleware>::from_env().unwrap();
+    let url = client.get_bucket_url();
+    assert_eq!(
+        url.as_str(),
+        "https://foo4.oss-cn-qingdao-internal.aliyuncs.com/"
+    );
+}
+
+#[test]
 fn test_builder_with_header() {
     let client = Client::<ClientWithMiddleware>::new(
         "foo1".into(),
         "foo2".into(),
-        EndPoint::CnQingdao,
+        EndPoint::CN_QINGDAO,
         "foo4".parse().unwrap(),
     );
     let url = "http://foo.example.net/foo".parse().unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,10 +140,11 @@ impl<'a> InnerKeySecret<'a> {
 
 /// # OSS 的可用区
 /// [aliyun docs](https://help.aliyun.com/document_detail/31837.htm)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct EndPoint {
     pub(crate) kind: EndPointKind,
+    /// default false
     pub(crate) is_internal: bool,
 }
 
@@ -267,15 +268,6 @@ impl EndPoint {
         kind: EndPointKind::ApSouthEast1,
         is_internal: false,
     };
-}
-
-impl Default for EndPoint {
-    fn default() -> Self {
-        Self {
-            kind: EndPointKind::default(),
-            is_internal: false,
-        }
-    }
 }
 
 /// # OSS 的可用区种类 enum
@@ -427,9 +419,9 @@ impl TryFrom<Url> for EndPoint {
         match url_pieces.next() {
             Some(endpoint) => match EndPoint::from_host_piece(endpoint) {
                 Ok(end) => Ok(end),
-                _ => return Err(InvalidEndPoint { _priv: () }),
+                _ => Err(InvalidEndPoint { _priv: () }),
             },
-            _ => return Err(InvalidEndPoint { _priv: () }),
+            _ => Err(InvalidEndPoint { _priv: () }),
         }
     }
 }
@@ -535,13 +527,7 @@ impl<'a> EndPoint {
             Ok(Other(Cow::Owned(url.to_owned())))
         };
 
-        match kind {
-            Ok(k) => Ok(Self {
-                kind: k,
-                is_internal,
-            }),
-            Err(e) => Err(e),
-        }
+        kind.map(|kind| Self { kind, is_internal })
     }
 
     /// 从 oss 域名中提取 Endpoint 信息

--- a/src/types.rs
+++ b/src/types.rs
@@ -151,120 +151,120 @@ pub struct EndPoint {
 impl EndPoint {
     /// 杭州
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_HANGZHOU")]
-    pub const CnHangzhou: EndPoint = EndPoint {
+    pub const CnHangzhou: Self = Self {
         kind: EndPointKind::CnHangzhou,
         is_internal: false,
     };
     /// 杭州
-    pub const CN_HANGZHOU: EndPoint = EndPoint {
+    pub const CN_HANGZHOU: Self = Self {
         kind: EndPointKind::CnHangzhou,
         is_internal: false,
     };
 
     /// 上海
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_SHANGHAI")]
-    pub const CnShanghai: EndPoint = EndPoint {
+    pub const CnShanghai: Self = Self {
         kind: EndPointKind::CnShanghai,
         is_internal: false,
     };
     /// 上海
-    pub const CN_SHANGHAI: EndPoint = EndPoint {
+    pub const CN_SHANGHAI: Self = Self {
         kind: EndPointKind::CnShanghai,
         is_internal: false,
     };
 
     /// 青岛
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_QINGDAO")]
-    pub const CnQingdao: EndPoint = EndPoint {
+    pub const CnQingdao: Self = Self {
         kind: EndPointKind::CnQingdao,
         is_internal: false,
     };
     /// 青岛
-    pub const CN_QINGDAO: EndPoint = EndPoint {
+    pub const CN_QINGDAO: Self = Self {
         kind: EndPointKind::CnQingdao,
         is_internal: false,
     };
 
     /// 北京
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_BEIJING")]
-    pub const CnBeijing: EndPoint = EndPoint {
+    pub const CnBeijing: Self = Self {
         kind: EndPointKind::CnBeijing,
         is_internal: false,
     };
     /// 北京
-    pub const CN_BEIJING: EndPoint = EndPoint {
+    pub const CN_BEIJING: Self = Self {
         kind: EndPointKind::CnBeijing,
         is_internal: false,
     };
 
     /// 张家口
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_ZHANGJIAKOU")]
-    pub const CnZhangjiakou: EndPoint = EndPoint {
+    pub const CnZhangjiakou: Self = Self {
         kind: EndPointKind::CnZhangjiakou,
         is_internal: false,
     };
     /// 张家口
-    pub const CN_ZHANGJIAKOU: EndPoint = EndPoint {
+    pub const CN_ZHANGJIAKOU: Self = Self {
         kind: EndPointKind::CnZhangjiakou,
         is_internal: false,
     };
 
     /// 香港
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_HONGKONG")]
-    pub const CnHongkong: EndPoint = EndPoint {
+    pub const CnHongkong: Self = Self {
         kind: EndPointKind::CnHongkong,
         is_internal: false,
     };
     /// 香港
-    pub const CN_HONGKONG: EndPoint = EndPoint {
+    pub const CN_HONGKONG: Self = Self {
         kind: EndPointKind::CnHongkong,
         is_internal: false,
     };
 
     /// 深圳
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_SHENZHEN")]
-    pub const CnShenzhen: EndPoint = EndPoint {
+    pub const CnShenzhen: Self = Self {
         kind: EndPointKind::CnShenzhen,
         is_internal: false,
     };
     /// 深圳
-    pub const CN_SHENZHEN: EndPoint = EndPoint {
+    pub const CN_SHENZHEN: Self = Self {
         kind: EndPointKind::CnShenzhen,
         is_internal: false,
     };
 
     /// UsWest1
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::US_WEST_1")]
-    pub const UsWest1: EndPoint = EndPoint {
+    pub const UsWest1: Self = Self {
         kind: EndPointKind::UsWest1,
         is_internal: false,
     };
     /// UsWest1
-    pub const US_WEST_1: EndPoint = EndPoint {
+    pub const US_WEST_1: Self = Self {
         kind: EndPointKind::UsWest1,
         is_internal: false,
     };
 
     /// UsEast1
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::US_EAST_1")]
-    pub const UsEast1: EndPoint = EndPoint {
+    pub const UsEast1: Self = Self {
         kind: EndPointKind::UsEast1,
         is_internal: false,
     };
     /// UsEast1
-    pub const US_EAST_1: EndPoint = EndPoint {
+    pub const US_EAST_1: Self = Self {
         kind: EndPointKind::UsEast1,
         is_internal: false,
     };
 
     /// ApSouthEast1
     #[deprecated(since = "0.13.0", note = "replace with EndPoint::AP_SOUTH_EAST_1")]
-    pub const ApSouthEast1: EndPoint = EndPoint {
+    pub const ApSouthEast1: Self = Self {
         kind: EndPointKind::ApSouthEast1,
         is_internal: false,
     };
     /// ApSouthEast1
-    pub const AP_SOUTH_EAST_1: EndPoint = EndPoint {
+    pub const AP_SOUTH_EAST_1: Self = Self {
         kind: EndPointKind::ApSouthEast1,
         is_internal: false,
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,9 +140,148 @@ impl<'a> InnerKeySecret<'a> {
 
 /// # OSS 的可用区
 /// [aliyun docs](https://help.aliyun.com/document_detail/31837.htm)
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EndPoint {
+    pub(crate) kind: EndPointKind,
+    pub(crate) is_internal: bool,
+}
+
+impl EndPoint {
+    /// 杭州
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_HANGZHOU")]
+    pub const CnHangzhou: EndPoint = EndPoint {
+        kind: EndPointKind::CnHangzhou,
+        is_internal: false,
+    };
+    /// 杭州
+    pub const CN_HANGZHOU: EndPoint = EndPoint {
+        kind: EndPointKind::CnHangzhou,
+        is_internal: false,
+    };
+
+    /// 上海
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_SHANGHAI")]
+    pub const CnShanghai: EndPoint = EndPoint {
+        kind: EndPointKind::CnShanghai,
+        is_internal: false,
+    };
+    /// 上海
+    pub const CN_SHANGHAI: EndPoint = EndPoint {
+        kind: EndPointKind::CnShanghai,
+        is_internal: false,
+    };
+
+    /// 青岛
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_QINGDAO")]
+    pub const CnQingdao: EndPoint = EndPoint {
+        kind: EndPointKind::CnQingdao,
+        is_internal: false,
+    };
+    /// 青岛
+    pub const CN_QINGDAO: EndPoint = EndPoint {
+        kind: EndPointKind::CnQingdao,
+        is_internal: false,
+    };
+
+    /// 北京
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_BEIJING")]
+    pub const CnBeijing: EndPoint = EndPoint {
+        kind: EndPointKind::CnBeijing,
+        is_internal: false,
+    };
+    /// 北京
+    pub const CN_BEIJING: EndPoint = EndPoint {
+        kind: EndPointKind::CnBeijing,
+        is_internal: false,
+    };
+
+    /// 张家口
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_ZHANGJIAKOU")]
+    pub const CnZhangjiakou: EndPoint = EndPoint {
+        kind: EndPointKind::CnZhangjiakou,
+        is_internal: false,
+    };
+    /// 张家口
+    pub const CN_ZHANGJIAKOU: EndPoint = EndPoint {
+        kind: EndPointKind::CnZhangjiakou,
+        is_internal: false,
+    };
+
+    /// 香港
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_HONGKONG")]
+    pub const CnHongkong: EndPoint = EndPoint {
+        kind: EndPointKind::CnHongkong,
+        is_internal: false,
+    };
+    /// 香港
+    pub const CN_HONGKONG: EndPoint = EndPoint {
+        kind: EndPointKind::CnHongkong,
+        is_internal: false,
+    };
+
+    /// 深圳
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::CN_SHENZHEN")]
+    pub const CnShenzhen: EndPoint = EndPoint {
+        kind: EndPointKind::CnShenzhen,
+        is_internal: false,
+    };
+    /// 深圳
+    pub const CN_SHENZHEN: EndPoint = EndPoint {
+        kind: EndPointKind::CnShenzhen,
+        is_internal: false,
+    };
+
+    /// UsWest1
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::US_WEST_1")]
+    pub const UsWest1: EndPoint = EndPoint {
+        kind: EndPointKind::UsWest1,
+        is_internal: false,
+    };
+    /// UsWest1
+    pub const US_WEST_1: EndPoint = EndPoint {
+        kind: EndPointKind::UsWest1,
+        is_internal: false,
+    };
+
+    /// UsEast1
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::US_EAST_1")]
+    pub const UsEast1: EndPoint = EndPoint {
+        kind: EndPointKind::UsEast1,
+        is_internal: false,
+    };
+    /// UsEast1
+    pub const US_EAST_1: EndPoint = EndPoint {
+        kind: EndPointKind::UsEast1,
+        is_internal: false,
+    };
+
+    /// ApSouthEast1
+    #[deprecated(since = "0.13.0", note = "replace with EndPoint::AP_SOUTH_EAST_1")]
+    pub const ApSouthEast1: EndPoint = EndPoint {
+        kind: EndPointKind::ApSouthEast1,
+        is_internal: false,
+    };
+    /// ApSouthEast1
+    pub const AP_SOUTH_EAST_1: EndPoint = EndPoint {
+        kind: EndPointKind::ApSouthEast1,
+        is_internal: false,
+    };
+}
+
+impl Default for EndPoint {
+    fn default() -> Self {
+        Self {
+            kind: EndPointKind::default(),
+            is_internal: false,
+        }
+    }
+}
+
+/// # OSS 的可用区种类 enum
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[non_exhaustive]
-pub enum EndPoint {
+pub(crate) enum EndPointKind {
     /// 杭州可用区
     #[default]
     CnHangzhou,
@@ -181,22 +320,22 @@ const AP_SOUTH_EAST1: &str = "ap-southeast-1";
 
 impl AsRef<str> for EndPoint {
     /// ```
-    /// # use aliyun_oss_client::types::EndPoint::*;
+    /// # use aliyun_oss_client::types::EndPoint;
     ///
-    /// assert_eq!(CnHangzhou.as_ref(), "cn-hangzhou");
-    /// assert_eq!(CnShanghai.as_ref(), "cn-shanghai");
-    /// assert_eq!(CnQingdao.as_ref(), "cn-qingdao");
-    /// assert_eq!(CnBeijing.as_ref(), "cn-beijing");
-    /// assert_eq!(CnZhangjiakou.as_ref(), "cn-zhangjiakou");
-    /// assert_eq!(CnHongkong.as_ref(), "cn-hongkong");
-    /// assert_eq!(CnShenzhen.as_ref(), "cn-shenzhen");
-    /// assert_eq!(UsWest1.as_ref(), "us-west-1");
-    /// assert_eq!(UsEast1.as_ref(), "us-east-1");
-    /// assert_eq!(ApSouthEast1.as_ref(), "ap-southeast-1");
+    /// assert_eq!(EndPoint::CnHangzhou.as_ref(), "cn-hangzhou");
+    /// assert_eq!(EndPoint::CnShanghai.as_ref(), "cn-shanghai");
+    /// assert_eq!(EndPoint::CnQingdao.as_ref(), "cn-qingdao");
+    /// assert_eq!(EndPoint::CnBeijing.as_ref(), "cn-beijing");
+    /// assert_eq!(EndPoint::CnZhangjiakou.as_ref(), "cn-zhangjiakou");
+    /// assert_eq!(EndPoint::CnHongkong.as_ref(), "cn-hongkong");
+    /// assert_eq!(EndPoint::CnShenzhen.as_ref(), "cn-shenzhen");
+    /// assert_eq!(EndPoint::UsWest1.as_ref(), "us-west-1");
+    /// assert_eq!(EndPoint::UsEast1.as_ref(), "us-east-1");
+    /// assert_eq!(EndPoint::ApSouthEast1.as_ref(), "ap-southeast-1");
     /// ```
     fn as_ref(&self) -> &str {
-        use EndPoint::*;
-        match self {
+        use EndPointKind::*;
+        match &self.kind {
             CnHangzhou => HANGZHOU,
             CnShanghai => SHANGHAI,
             CnQingdao => QINGDAO,
@@ -214,8 +353,8 @@ impl AsRef<str> for EndPoint {
 
 impl Display for EndPoint {
     /// ```
-    /// # use aliyun_oss_client::types::EndPoint::*;
-    /// assert_eq!(format!("{}", CnHangzhou), "cn-hangzhou");
+    /// # use aliyun_oss_client::types::EndPoint;
+    /// assert_eq!(format!("{}", EndPoint::CnHangzhou), "cn-hangzhou");
     /// ```
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_ref())
@@ -287,7 +426,10 @@ impl<'a> EndPoint {
     /// # Safety
     /// 用于静态定义其他可用区
     pub const unsafe fn from_static2(url: &'static str) -> Self {
-        EndPoint::Other(Cow::Borrowed(url))
+        Self {
+            kind: EndPointKind::Other(Cow::Borrowed(url)),
+            is_internal: false,
+        }
     }
 
     /// 初始化 endpoint enum
@@ -299,12 +441,6 @@ impl<'a> EndPoint {
     ///     Ok(EndPoint::CnShanghai)
     /// ));
     ///
-    /// let weifang = "weifang".to_string();
-    /// assert!(matches!(
-    ///     EndPoint::new("weifang"),
-    ///     Ok(EndPoint::Other(Cow::Owned(weifang)))
-    /// ));
-    ///
     /// assert!(EndPoint::new("abc-").is_err());
     /// assert!(EndPoint::new("-abc").is_err());
     /// assert!(EndPoint::new("abc-def234ab").is_ok());
@@ -313,12 +449,12 @@ impl<'a> EndPoint {
     /// assert!(EndPoint::new("oss-cn-jinan").is_err());
     /// ```
     pub fn new(url: &'a str) -> Result<Self, InvalidEndPoint> {
-        use EndPoint::*;
+        use EndPointKind::*;
         if url.is_empty() {
             return Err(InvalidEndPoint { _priv: () });
         }
 
-        if url.contains(SHANGHAI_L) {
+        let kind = if url.contains(SHANGHAI_L) {
             Ok(CnShanghai)
         } else if url.contains(HANGZHOU_L) {
             Ok(CnHangzhou)
@@ -360,6 +496,14 @@ impl<'a> EndPoint {
             }
 
             Ok(Other(Cow::Owned(url.to_owned())))
+        };
+
+        match kind {
+            Ok(k) => Ok(Self {
+                kind: k,
+                is_internal: false,
+            }),
+            Err(e) => Err(e),
         }
     }
 
@@ -370,6 +514,11 @@ impl<'a> EndPoint {
             return Err(InvalidEndPoint { _priv: () });
         }
         Self::new(&url[4..])
+    }
+
+    /// 设置 internal，当在 Aliyun ECS 上执行时，设为 true 会更高效，默认是 false
+    pub fn set_internal(&mut self, is_internal: bool) {
+        self.is_internal = is_internal;
     }
 
     /// 转化成 Url
@@ -391,12 +540,11 @@ impl<'a> EndPoint {
     /// );
     /// ```
     pub fn to_url(&self) -> Url {
-        use std::env;
         let mut url = String::from(OSS_DOMAIN_PREFIX);
         url.push_str(self.as_ref());
 
         // internal
-        if env::var("ALIYUN_OSS_INTERNAL").is_ok() {
+        if self.is_internal {
             url.push_str(OSS_INTERNAL);
         }
 

--- a/src/types/object/test.rs
+++ b/src/types/object/test.rs
@@ -46,7 +46,7 @@ mod test_core {
     #[test]
     fn object_base_debug() {
         let object = ObjectBase::<ArcPointer>::default();
-        assert_eq!(format!("{object:?}"), "ObjectBase { bucket: BucketBase { endpoint: CnHangzhou, name: BucketName(\"a\") }, path: ObjectPathInner(\"\") }");
+        assert_eq!(format!("{object:?}"), "ObjectBase { bucket: BucketBase { endpoint: EndPoint { kind: CnHangzhou, is_internal: false }, name: BucketName(\"a\") }, path: ObjectPathInner(\"\") }");
     }
 
     #[test]

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -105,9 +105,27 @@ mod test_endpoint {
                 ..
             })
         ));
+
+        assert!(matches!(
+            EndPoint::new("https://oss-cn-qingdao-internal.aliyuncs.com"),
+            Ok(EndPoint {
+                kind: EndPointKind::CnQingdao,
+                is_internal: false,
+            })
+        ));
+        assert!(matches!(
+            EndPoint::new("https://oss-cn-qingdao.aliyuncs.com"),
+            Ok(EndPoint {
+                kind: EndPointKind::CnQingdao,
+                is_internal: false,
+            })
+        ));
+
+        let res = EndPoint::new("abc-internal").unwrap();
+        assert_eq!(res.is_internal, true);
+        assert_eq!(res.as_ref(), "abc");
     }
 
-    #[cfg(feature = "auth")]
     #[test]
     fn test_from_host_piece() {
         assert!(EndPoint::from_host_piece("qingdao").is_err());
@@ -118,8 +136,33 @@ mod test_endpoint {
         );
         assert_eq!(
             EndPoint::from_host_piece("oss-qingdao"),
-            Ok(EndPoint::CnQingdao)
+            Ok(EndPoint {
+                kind: EndPointKind::CnQingdao,
+                is_internal: false,
+            })
         );
+        assert_eq!(
+            EndPoint::from_host_piece("oss-qingdao-internal"),
+            Ok(EndPoint {
+                kind: EndPointKind::CnQingdao,
+                is_internal: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_from_url() {
+        let url = Url::parse("https://oss-cn-qingdao.aliyuncs.com/").unwrap();
+        let endpoint = EndPoint::try_from(url).unwrap();
+
+        assert!(matches!(endpoint.kind, EndPointKind::CnQingdao));
+        assert_eq!(endpoint.is_internal, false);
+
+        let url = Url::parse("https://oss-cn-qingdao-internal.aliyuncs.com/").unwrap();
+        let endpoint = EndPoint::try_from(url).unwrap();
+
+        assert!(matches!(endpoint.kind, EndPointKind::CnQingdao));
+        assert_eq!(endpoint.is_internal, true);
     }
 }
 

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -1,11 +1,9 @@
-use std::borrow::Cow;
-
 use chrono::{TimeZone, Utc};
 use http::HeaderValue;
 use reqwest::Url;
 
 use crate::{
-    types::{CanonicalizedResource, InvalidBucketName},
+    types::{CanonicalizedResource, EndPointKind, InvalidBucketName},
     BucketName, EndPoint, KeyId, KeySecret,
 };
 
@@ -38,7 +36,10 @@ fn endpoint() {
 
     assert_eq!(end.as_ref(), "aaa");
 
-    let end1 = EndPoint::Other(Cow::Borrowed("aaa"));
+    let end1 = EndPoint {
+        kind: EndPointKind::Other("aaa".into()),
+        is_internal: false,
+    };
     assert_eq!(end1.as_ref(), "aaa");
 
     assert!(EndPoint::new("").is_err());
@@ -52,6 +53,8 @@ fn endpoint() {
 }
 
 mod test_endpoint {
+    use std::borrow::Cow;
+
     use super::*;
 
     #[test]
@@ -93,6 +96,14 @@ mod test_endpoint {
         assert!(matches!(
             EndPoint::new("ap-southeast-1"),
             Ok(EndPoint::ApSouthEast1)
+        ));
+
+        assert!(matches!(
+            EndPoint::new("weifang"),
+            Ok(EndPoint {
+                kind: EndPointKind::Other(Cow::Owned(_)),
+                ..
+            })
         ));
     }
 

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -163,6 +163,21 @@ mod test_endpoint {
 
         assert!(matches!(endpoint.kind, EndPointKind::CnQingdao));
         assert_eq!(endpoint.is_internal, true);
+
+        let url = Url::parse("https://192.168.3.1/").unwrap();
+        assert!(EndPoint::try_from(url).is_err());
+
+        let url = Url::parse("https://oss-cn-qingdao-internal.aliyuncs.cn/").unwrap();
+        assert!(EndPoint::try_from(url).is_err());
+
+        let url = Url::parse("https://oss-cn-qingdao-internal.aliyun.com/").unwrap();
+        assert!(EndPoint::try_from(url).is_err());
+
+        let url = Url::parse("https://aliyuncs.com/").unwrap();
+        assert!(EndPoint::try_from(url).is_err());
+
+        let url = Url::parse("https://-cn-qingdao.aliyuncs.com/").unwrap();
+        assert!(EndPoint::try_from(url).is_err());
     }
 }
 


### PR DESCRIPTION
add is_internal field.

before Endpoint is an Enum ,now it changed to struct ,and it has two field:

- `is_internal`, signal endpoint is or not internal, default value false
- `kind`, an enum, signal `hangzhou` or `qingdao` or other endpoint