### PR TITLE
feat(decode)!: remove init object fn, and add InitObject trait

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -50,7 +50,7 @@ async fn get_with_client() -> Result<(), ExtractListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &MyBucket) -> MyFile {
+    fn init_file(_list: &mut MyBucket) -> MyFile {
         MyFile {
             key: String::default(),
             other: "abc".to_string(),

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,9 +1,7 @@
-use std::env;
-
 use aliyun_oss_client::{
     decode::{RefineObject, RefineObjectList},
     object::ExtractListError,
-    BucketName, Client, DecodeListError,
+    Client, DecodeListError,
 };
 use dotenv::dotenv;
 use thiserror::Error;
@@ -52,11 +50,12 @@ async fn get_with_client() -> Result<(), ExtractListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    let init_file = || MyFile {
-        key: String::default(),
-        other: "abc".to_string(),
-    };
-    let bucket_name = env::var("ALIYUN_BUCKET").unwrap();
+    fn init_file(_list: &MyBucket) -> MyFile {
+        MyFile {
+            key: String::default(),
+            other: "abc".to_string(),
+        }
+    }
 
     client.base_object_list([], &mut bucket, init_file).await?;
 

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -50,8 +50,8 @@ async fn get_with_client() -> Result<(), ExtractListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &mut MyBucket) -> Result<MyFile, MyError> {
-        Ok(MyFile {
+    fn init_file(_list: &mut MyBucket) -> Option<MyFile> {
+        Some(MyFile {
             key: String::default(),
             other: "abc".to_string(),
         })

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -50,11 +50,11 @@ async fn get_with_client() -> Result<(), ExtractListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &mut MyBucket) -> MyFile {
-        MyFile {
+    fn init_file(_list: &mut MyBucket) -> Result<MyFile, MyError> {
+        Ok(MyFile {
             key: String::default(),
             other: "abc".to_string(),
-        }
+        })
     }
 
     client.base_object_list([], &mut bucket, init_file).await?;

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,6 +1,6 @@
 use aliyun_oss_client::{
     decode::{RefineObject, RefineObjectList},
-    object::ExtractListError,
+    object::{ExtractListError, InitObject},
     Client, DecodeListError,
 };
 use dotenv::dotenv;
@@ -47,17 +47,22 @@ async fn get_with_client() -> Result<(), ExtractListError> {
     let client = Client::from_env().unwrap();
 
     // 除了设置Default 外，还可以做更多设置
-    let mut bucket = MyBucket::default();
+    let mut bucket = MyBucket {
+        name: "abc".to_string(),
+        files: Vec::with_capacity(20),
+    };
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &mut MyBucket) -> Option<MyFile> {
-        Some(MyFile {
-            key: String::default(),
-            other: "abc".to_string(),
-        })
+    impl InitObject<MyFile> for MyBucket {
+        fn init_object(&mut self) -> Option<MyFile> {
+            Some(MyFile {
+                key: String::default(),
+                other: "abc".to_string(),
+            })
+        }
     }
 
-    client.base_object_list([], &mut bucket, init_file).await?;
+    client.base_object_list([], &mut bucket).await?;
 
     println!("bucket: {:?}", bucket);
 

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -38,7 +38,7 @@ async fn main() {
 
     let _ = client.base_object_list([], &mut list, init_object).await;
 
-    let _second = list.get_next_base(init_object).await.unwrap();
+    let _second = list.get_next_base(init_object).await;
 
     println!("list: {:?}", list.to_vec());
 }

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -2,7 +2,7 @@ use aliyun_oss_client::{
     decode::RefineObject,
     object::Objects,
     types::object::{InvalidObjectDir, ObjectDir, ObjectPathInner},
-    BucketName, Client,
+    Client,
 };
 use dotenv::dotenv;
 
@@ -32,7 +32,9 @@ async fn main() {
 
     let mut list = MyList::default();
 
-    let init_object = || MyObject::File(ObjectPathInner::default());
+    fn init_object<'a, 'b>(_list: &'a MyList<'b>) -> MyObject<'b> {
+        MyObject::File(ObjectPathInner::default())
+    }
 
     let _ = client.base_object_list([], &mut list, init_object).await;
 

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -32,8 +32,8 @@ async fn main() {
 
     let mut list = MyList::default();
 
-    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> MyObject<'b> {
-        MyObject::File(ObjectPathInner::default())
+    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> Result<MyObject<'b>, InvalidObjectDir> {
+        Ok(MyObject::File(ObjectPathInner::default()))
     }
 
     let _ = client.base_object_list([], &mut list, init_object).await;

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -1,6 +1,6 @@
 use aliyun_oss_client::{
     decode::RefineObject,
-    object::Objects,
+    object::{InitObject, Objects},
     types::object::{InvalidObjectDir, ObjectDir, ObjectPathInner},
     Client,
 };
@@ -24,6 +24,12 @@ impl RefineObject<InvalidObjectDir> for MyObject<'_> {
 
 type MyList<'a> = Objects<MyObject<'a>>;
 
+impl<'a> InitObject<MyObject<'a>> for MyList<'a> {
+    fn init_object(&mut self) -> Option<MyObject<'a>> {
+        Some(MyObject::File(ObjectPathInner::default()))
+    }
+}
+
 #[tokio::main]
 async fn main() {
     dotenv().ok();
@@ -32,13 +38,9 @@ async fn main() {
 
     let mut list = MyList::default();
 
-    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> Option<MyObject<'b>> {
-        Some(MyObject::File(ObjectPathInner::default()))
-    }
+    let _ = client.base_object_list([], &mut list).await;
 
-    let _ = client.base_object_list([], &mut list, init_object).await;
-
-    let _second = list.get_next_base(init_object).await;
+    let _second = list.get_next_base().await;
 
     println!("list: {:?}", list.to_vec());
 }

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -32,8 +32,8 @@ async fn main() {
 
     let mut list = MyList::default();
 
-    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> Result<MyObject<'b>, InvalidObjectDir> {
-        Ok(MyObject::File(ObjectPathInner::default()))
+    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> Option<MyObject<'b>> {
+        Some(MyObject::File(ObjectPathInner::default()))
     }
 
     let _ = client.base_object_list([], &mut list, init_object).await;

--- a/examples/object_custom.rs
+++ b/examples/object_custom.rs
@@ -32,7 +32,7 @@ async fn main() {
 
     let mut list = MyList::default();
 
-    fn init_object<'a, 'b>(_list: &'a MyList<'b>) -> MyObject<'b> {
+    fn init_object<'a, 'b>(_list: &'a mut MyList<'b>) -> MyObject<'b> {
         MyObject::File(ObjectPathInner::default())
     }
 

--- a/examples/parse_xml.rs
+++ b/examples/parse_xml.rs
@@ -61,10 +61,12 @@ fn get_with_xml() -> Result<(), InnerListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    let init_file = || MyFile {
-        key: String::default(),
-        other: "abc".to_string(),
-    };
+    fn init_file(_list: &MyBucket) -> MyFile {
+        MyFile {
+            key: String::default(),
+            other: "abc".to_string(),
+        }
+    }
 
     bucket.decode(xml, init_file)?;
 

--- a/examples/parse_xml.rs
+++ b/examples/parse_xml.rs
@@ -61,7 +61,7 @@ fn get_with_xml() -> Result<(), InnerListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &MyBucket) -> MyFile {
+    fn init_file(_list: &mut MyBucket) -> MyFile {
         MyFile {
             key: String::default(),
             other: "abc".to_string(),

--- a/examples/parse_xml.rs
+++ b/examples/parse_xml.rs
@@ -61,11 +61,11 @@ fn get_with_xml() -> Result<(), InnerListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &mut MyBucket) -> MyFile {
-        MyFile {
+    fn init_file(_list: &mut MyBucket) -> std::io::Result<MyFile> {
+        Ok(MyFile {
             key: String::default(),
             other: "abc".to_string(),
-        }
+        })
     }
 
     bucket.decode(xml, init_file)?;

--- a/examples/parse_xml.rs
+++ b/examples/parse_xml.rs
@@ -61,8 +61,8 @@ fn get_with_xml() -> Result<(), InnerListError> {
     let mut bucket = MyBucket::default();
 
     // 利用闭包对 MyFile 做一下初始化设置
-    fn init_file(_list: &mut MyBucket) -> std::io::Result<MyFile> {
-        Ok(MyFile {
+    fn init_file(_list: &mut MyBucket) -> Option<MyFile> {
+        Some(MyFile {
             key: String::default(),
             other: "abc".to_string(),
         })

--- a/src/auth/query.rs
+++ b/src/auth/query.rs
@@ -9,12 +9,7 @@
 //! let key = "key".into();
 //! let secret = "secret".into();
 //! let bucket = "bucket".parse().unwrap();
-//! let auth = QueryAuth::new(
-//!     &key,
-//!     &secret,
-//!     &EndPoint::CN_QINGDAO,
-//!     &bucket
-//! );
+//! let auth = QueryAuth::new(&key, &secret, &EndPoint::CN_QINGDAO, &bucket);
 //! let time = Utc::now().timestamp() + 3600;
 //! let url = auth.to_url(&"pretty.png".parse().unwrap(), time);
 //! ```

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -22,6 +22,7 @@ use crate::{BucketName, EndPoint};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use http::Method;
 use oss_derive::oss_gen_rc;
+use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::{self, Display};
 use std::num::ParseIntError;
@@ -376,7 +377,7 @@ impl Bucket {
         let (bucket_url, resource) = bucket_arc.get_url_resource(&query);
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error().await?;
-        fn init_object_with_list(list: &mut ObjectList) -> Result<Object, std::io::Error> {
+        fn init_object_with_list(list: &mut ObjectList) -> Result<Object, Infallible> {
             Ok(Object::from_bucket(Arc::new(list.bucket.clone())))
         }
         list.decode(&content.text().await?, init_object_with_list)?;
@@ -409,7 +410,7 @@ impl Bucket<RcPointer> {
 
         fn init_object_with_list(
             list: &mut ObjectList<RcPointer>,
-        ) -> Result<Object<RcPointer>, std::io::Error> {
+        ) -> Result<Object<RcPointer>, Infallible> {
             Ok(Object::<RcPointer>::from_bucket(Rc::new(
                 list.bucket.clone(),
             )))

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -470,9 +470,9 @@ impl InitObject<Bucket> for ListBuckets {
 
 #[cfg(feature = "blocking")]
 impl InitObject<Bucket<RcPointer>> for ListBuckets<RcPointer> {
-  fn init_object(&mut self) -> Option<Bucket<RcPointer>> {
-      Bucket::<RcPointer>::from_list(self)
-  }
+    fn init_object(&mut self) -> Option<Bucket<RcPointer>> {
+        Bucket::<RcPointer>::from_list(self)
+    }
 }
 
 impl ClientArc {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -407,8 +407,12 @@ impl Bucket<RcPointer> {
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error()?;
 
-        fn init_object_with_list(list: &mut ObjectList<RcPointer>) -> Object<RcPointer> {
-            Object::<RcPointer>::from_bucket(Rc::new(list.bucket.clone()))
+        fn init_object_with_list(
+            list: &mut ObjectList<RcPointer>,
+        ) -> Result<Object<RcPointer>, std::io::Error> {
+            Ok(Object::<RcPointer>::from_bucket(Rc::new(
+                list.bucket.clone(),
+            )))
         }
 
         list.decode(&content.text()?, init_object_with_list)?;

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -407,9 +407,11 @@ impl Bucket<RcPointer> {
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error()?;
 
-        list.decode(&content.text()?, || {
-            Object::<RcPointer>::from_bucket(bucket_arc.clone())
-        })?;
+        fn init_object_with_list(list: &ObjectList<RcPointer>) -> Object<RcPointer> {
+            Object::<RcPointer>::from_bucket(Rc::new(list.bucket.clone()))
+        }
+
+        list.decode(&content.text()?, init_object_with_list)?;
         list.set_search_query(query);
 
         Ok(list)

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -376,8 +376,8 @@ impl Bucket {
         let (bucket_url, resource) = bucket_arc.get_url_resource(&query);
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error().await?;
-        fn init_object_with_list(list: &mut ObjectList) -> Object {
-            Object::from_bucket(Arc::new(list.bucket.clone()))
+        fn init_object_with_list(list: &mut ObjectList) -> Result<Object, std::io::Error> {
+            Ok(Object::from_bucket(Arc::new(list.bucket.clone())))
         }
         list.decode(&content.text().await?, init_object_with_list)?;
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -376,9 +376,10 @@ impl Bucket {
         let (bucket_url, resource) = bucket_arc.get_url_resource(&query);
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error().await?;
-        list.decode(&content.text().await?, || {
-            Object::from_bucket(bucket_arc.clone())
-        })?;
+        fn init_object_with_list(list: &ObjectList) -> Object {
+            Object::from_bucket(Arc::new(list.bucket.clone()))
+        }
+        list.decode(&content.text().await?, init_object_with_list)?;
 
         list.set_search_query(query);
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -376,7 +376,7 @@ impl Bucket {
         let (bucket_url, resource) = bucket_arc.get_url_resource(&query);
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error().await?;
-        fn init_object_with_list(list: &ObjectList) -> Object {
+        fn init_object_with_list(list: &mut ObjectList) -> Object {
             Object::from_bucket(Arc::new(list.bucket.clone()))
         }
         list.decode(&content.text().await?, init_object_with_list)?;
@@ -407,7 +407,7 @@ impl Bucket<RcPointer> {
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error()?;
 
-        fn init_object_with_list(list: &ObjectList<RcPointer>) -> Object<RcPointer> {
+        fn init_object_with_list(list: &mut ObjectList<RcPointer>) -> Object<RcPointer> {
             Object::<RcPointer>::from_bucket(Rc::new(list.bucket.clone()))
         }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -377,8 +377,8 @@ impl Bucket {
         let (bucket_url, resource) = bucket_arc.get_url_resource(&query);
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error().await?;
-        fn init_object_with_list(list: &mut ObjectList) -> Result<Object, Infallible> {
-            Ok(Object::from_bucket(Arc::new(list.bucket.clone())))
+        fn init_object_with_list(list: &mut ObjectList) -> Option<Object> {
+            Some(Object::from_bucket(Arc::new(list.bucket.clone())))
         }
         list.decode(&content.text().await?, init_object_with_list)?;
 
@@ -408,10 +408,8 @@ impl Bucket<RcPointer> {
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error()?;
 
-        fn init_object_with_list(
-            list: &mut ObjectList<RcPointer>,
-        ) -> Result<Object<RcPointer>, Infallible> {
-            Ok(Object::<RcPointer>::from_bucket(Rc::new(
+        fn init_object_with_list(list: &mut ObjectList<RcPointer>) -> Option<Object<RcPointer>> {
+            Some(Object::<RcPointer>::from_bucket(Rc::new(
                 list.bucket.clone(),
             )))
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -202,6 +202,16 @@ impl<M> Client<M> {
         self.endpoint.to_url()
     }
 
+    /// 更改默认 bucket
+    pub fn set_bucket(&mut self, bucket: BucketName) {
+        self.bucket = bucket;
+    }
+
+    /// 更改默认 endpoint
+    pub fn set_endpoint(&mut self, endpoint: EndPoint) {
+        self.endpoint = endpoint;
+    }
+
     /// 设置 timeout
     pub fn timeout(&mut self, timeout: Duration) {
         self.timeout = Some(timeout);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -71,10 +71,12 @@
 //!     let mut bucket = MyBucket::default();
 //!
 //!     // 利用闭包对 MyFile 做一下初始化设置
-//!     let init_file = || MyFile {
-//!         key: String::default(),
-//!         other: "abc".to_string(),
-//!     };
+//!     fn init_file<'a>(_list: &'a MyBucket) -> MyFile {
+//!         MyFile {
+//!             key: String::default(),
+//!             other: "abc".to_string(),
+//!         }
+//!     }
 //!
 //!     bucket.decode(xml, init_file)?;
 //!

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -601,11 +601,11 @@ impl InnerListError {
         }
     }
 
-    fn custom<E: StdError + 'static>(err: E) -> Self {
-        Self {
-            kind: ListErrorKind::Custom(Box::new(err)),
-        }
-    }
+    // fn custom<E: StdError + 'static>(err: E) -> Self {
+    //     Self {
+    //         kind: ListErrorKind::Custom(Box::new(err)),
+    //     }
+    // }
 
     fn init_error() -> Self {
         Self {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -278,9 +278,9 @@ where
 
     /// # 由 xml 转 struct 的底层实现
     /// - `init_object` 用于初始化 object 结构体的方法
-    fn decode<F>(&mut self, xml: &str, mut init_object: F) -> Result<(), InnerListError>
+    fn decode<F>(&mut self, xml: &str, init_object: F) -> Result<(), InnerListError>
     where
-        F: FnMut() -> T,
+        F: for<'a> Fn(&'a Self) -> T,
     {
         //println!("from_xml: {:#}", xml);
         let mut result = Vec::new();
@@ -311,7 +311,7 @@ where
                         }
                         CONTENTS => {
                             // <Contents></Contents> 标签内部的数据对应单个 object 信息
-                            let mut object = init_object();
+                            let mut object = init_object(&self);
                             object.decode(&reader.read_text(e.to_end().name())?)?;
                             result.push(object);
                         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -72,11 +72,11 @@
 //!
 //!     // 利用闭包对 MyFile 做一下初始化设置
 //!     // 可以根据传入的列表信息，为元素添加更多能力
-//!     fn init_file(_list: &mut MyBucket) -> MyFile {
-//!         MyFile {
+//!     fn init_file(_list: &mut MyBucket) -> std::io::Result<MyFile> {
+//!         Ok(MyFile {
 //!             key: String::default(),
 //!             other: "abc".to_string(),
-//!         }
+//!         })
 //!     }
 //!
 //!     bucket.decode(xml, init_file)?;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -41,7 +41,7 @@
 //!
 //! use aliyun_oss_client::DecodeListError;
 //!
-//! // 自定义的 Error 需要实现这两个 Trait，用于内部解析方法在调用时，统一处理异常
+//! // 自定义的 Error 需要实现这个 Trait，用于内部解析方法在调用时，统一处理异常
 //! #[derive(Debug, Error, DecodeListError)]
 //! #[error("my error")]
 //! struct MyError {}
@@ -71,7 +71,8 @@
 //!     let mut bucket = MyBucket::default();
 //!
 //!     // 利用闭包对 MyFile 做一下初始化设置
-//!     fn init_file<'a>(_list: &'a MyBucket) -> MyFile {
+//!     // 可以根据传入的列表信息，为元素添加更多能力
+//!     fn init_file(_list: &mut MyBucket) -> MyFile {
 //!         MyFile {
 //!             key: String::default(),
 //!             other: "abc".to_string(),
@@ -282,7 +283,7 @@ where
     /// - `init_object` 用于初始化 object 结构体的方法
     fn decode<F>(&mut self, xml: &str, init_object: F) -> Result<(), InnerListError>
     where
-        F: for<'a> Fn(&'a Self) -> T,
+        F: for<'a> Fn(&'a mut Self) -> T,
     {
         //println!("from_xml: {:#}", xml);
         let mut result = Vec::new();
@@ -313,7 +314,7 @@ where
                         }
                         CONTENTS => {
                             // <Contents></Contents> 标签内部的数据对应单个 object 信息
-                            let mut object = init_object(&self);
+                            let mut object = init_object(self);
                             object.decode(&reader.read_text(e.to_end().name())?)?;
                             result.push(object);
                         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -587,7 +587,7 @@ impl Display for InnerListError {
             Item(item) => write!(fmt, "{}", item.0),
             Xml(xml) => write!(fmt, "{xml}"),
             Custom(out) => write!(fmt, "{out}"),
-            InitItemFailed => write!(fmt, "init item failed"),
+            InitItemFailed => write!(fmt, "init_object failed"),
         }
     }
 }

--- a/src/decode/test.rs
+++ b/src/decode/test.rs
@@ -618,7 +618,7 @@ mod bucket_list_xml {
         </ListAllMyBucketsResult>"#;
 
         let mut list = ListA {};
-        let res = list.decode(xml, || BucketA {});
+        let res = list.decode(xml, |_| Some(BucketA {}));
 
         assert!(res.is_ok());
     }

--- a/src/decode/test.rs
+++ b/src/decode/test.rs
@@ -161,9 +161,7 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        let res = list.decode(xml, |_| -> Result<ObjectA, std::io::Error> {
-            Ok(ObjectA {})
-        });
+        let res = list.decode(xml, |_| -> Option<ObjectA> { Some(ObjectA {}) });
 
         assert!(res.is_ok());
     }
@@ -411,8 +409,8 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        fn init_object(_list: &mut ListB) -> std::io::Result<ObjectA> {
-            Ok(ObjectA {})
+        fn init_object(_list: &mut ListB) -> Option<ObjectA> {
+            Some(ObjectA {})
         }
 
         let res = list.decode(xml, init_object);
@@ -763,9 +761,7 @@ mod some_tests {
 
         let mut list = ListA {};
 
-        let res = list.decode(xml, |_| -> Result<ObjectA, std::io::Error> {
-            Ok(ObjectA {})
-        });
+        let res = list.decode(xml, |_| -> Option<ObjectA> { Some(ObjectA {}) });
 
         assert!(res.is_ok());
     }

--- a/src/decode/test.rs
+++ b/src/decode/test.rs
@@ -161,7 +161,9 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        let res = list.decode(xml, |_| ObjectA {});
+        let res = list.decode(xml, |_| -> Result<ObjectA, std::io::Error> {
+            Ok(ObjectA {})
+        });
 
         assert!(res.is_ok());
     }
@@ -409,8 +411,8 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        fn init_object(_list: &mut ListB) -> ObjectA {
-            ObjectA {}
+        fn init_object(_list: &mut ListB) -> std::io::Result<ObjectA> {
+            Ok(ObjectA {})
         }
 
         let res = list.decode(xml, init_object);
@@ -761,7 +763,9 @@ mod some_tests {
 
         let mut list = ListA {};
 
-        let res = list.decode(xml, |_| ObjectA {});
+        let res = list.decode(xml, |_| -> Result<ObjectA, std::io::Error> {
+            Ok(ObjectA {})
+        });
 
         assert!(res.is_ok());
     }

--- a/src/decode/test.rs
+++ b/src/decode/test.rs
@@ -161,7 +161,7 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        let res = list.decode(xml, || ObjectA {});
+        let res = list.decode(xml, |_| ObjectA {});
 
         assert!(res.is_ok());
     }
@@ -409,7 +409,9 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        let init_object = || ObjectA {};
+        fn init_object(_list: &ListB) -> ObjectA {
+            ObjectA {}
+        }
 
         let res = list.decode(xml, init_object);
 
@@ -759,7 +761,7 @@ mod some_tests {
 
         let mut list = ListA {};
 
-        let res = list.decode(xml, || ObjectA {});
+        let res = list.decode(xml, |_| ObjectA {});
 
         assert!(res.is_ok());
     }

--- a/src/decode/test.rs
+++ b/src/decode/test.rs
@@ -409,7 +409,7 @@ mod object_list_xml {
 
         let mut list = ListB {};
 
-        fn init_object(_list: &ListB) -> ObjectA {
+        fn init_object(_list: &mut ListB) -> ObjectA {
             ObjectA {}
         }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -40,13 +40,11 @@
 //!
 //!     let mut list = MyList::default();
 //!
-//!     fn init_object<'a,>(_list: &'a MyList) -> MyObject {
+//!     fn init_object(_list: &MyList) -> MyObject {
 //!         MyObject::File(ObjectPath::default())
 //!     }
 //!
-//!     let _ = client
-//!         .base_object_list([], &mut list, init_object)
-//!         .await;
+//!     let _ = client.base_object_list([], &mut list, init_object).await;
 //!     // 第二页数据
 //!     let second = list.get_next_base(init_object).await;
 //!
@@ -1109,9 +1107,7 @@ impl Client {
     ///         }
     ///     }
     ///
-    ///     client
-    ///         .base_object_list([], &mut bucket, init_file)
-    ///         .await?;
+    ///     client.base_object_list([], &mut bucket, init_file).await?;
     ///
     ///     println!("bucket: {:?}", bucket);
     ///

--- a/src/object.rs
+++ b/src/object.rs
@@ -335,7 +335,7 @@ impl InitObject<Object<ArcPointer>> for ObjectList<ArcPointer, Object<ArcPointer
 impl InitObject<Object<RcPointer>> for ObjectList<RcPointer, Object<RcPointer>> {
     fn init_object(&mut self) -> Option<Object<RcPointer>> {
         Some(Object::<RcPointer>::from_bucket(Rc::new(
-            list.bucket.clone(),
+            self.bucket.clone(),
         )))
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1112,8 +1112,8 @@ impl Client {
     ///     let mut bucket = MyBucket::default();
     ///
     ///     // 利用闭包对 MyFile 做一下初始化设置
-    ///     fn init_file(_list: &mut MyBucket) -> Result<MyFile, MyError> {
-    ///         Ok(MyFile {
+    ///     fn init_file(_list: &mut MyBucket) -> Option<MyFile> {
+    ///         Some(MyFile {
     ///             key: String::default(),
     ///             other: "abc".to_string(),
     ///         })

--- a/src/object.rs
+++ b/src/object.rs
@@ -1328,7 +1328,7 @@ impl ClientRc {
     where
         List: RefineObjectList<Item, E, ItemErr>,
         Item: RefineObject<ItemErr>,
-        F: Fn(&mut List) -> Result<Item, ItemErr>,
+        F: Fn(&mut List) -> Option<Item>,
     {
         let bucket = BucketBase::new(self.bucket.clone(), self.get_endpoint().to_owned());
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -1113,7 +1113,7 @@ impl Client {
     ///     let mut bucket = MyBucket::default();
     ///
     ///     // 利用闭包对 MyFile 做一下初始化设置
-    ///     fn init_file(_list: &mut MyBucket) -> std::io::Result<MyFile> {
+    ///     fn init_file(_list: &mut MyBucket) -> Result<MyFile, MyError> {
     ///         Ok(MyFile {
     ///             key: String::default(),
     ///             other: "abc".to_string(),
@@ -1320,7 +1320,6 @@ impl ClientRc {
         F,
         E: ListError,
         ItemErr: Error + 'static,
-        FnErr,
     >(
         &self,
         query: Q,
@@ -1330,8 +1329,7 @@ impl ClientRc {
     where
         List: RefineObjectList<Item, E, ItemErr>,
         Item: RefineObject<ItemErr>,
-        FnErr: Error + 'static,
-        F: Fn(&mut List) -> Result<Item, FnErr>,
+        F: Fn(&mut List) -> Result<Item, ItemErr>,
     {
         let bucket = BucketBase::new(self.bucket.clone(), self.get_endpoint().to_owned());
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -40,7 +40,9 @@
 //!
 //!     let mut list = MyList::default();
 //!
-//!     let init_object = || MyObject::File(ObjectPath::default());
+//!     fn init_object<'a,>(_list: &'a MyList) -> MyObject {
+//!         MyObject::File(ObjectPath::default())
+//!     }
 //!
 //!     let _ = client
 //!         .base_object_list([], &mut list, init_object)

--- a/src/object.rs
+++ b/src/object.rs
@@ -42,8 +42,8 @@
 //!
 //!     // 利用闭包对 MyFile 做一下初始化设置
 //!     // 可以根据传入的列表信息，为元素添加更多能力
-//!     fn init_object(_list: &mut MyList) -> MyObject {
-//!         MyObject::File(ObjectPath::default())
+//!     fn init_object(_list: &mut MyList) -> std::io::Result<MyObject> {
+//!         Ok(MyObject::File(ObjectPath::default()))
 //!     }
 //!
 //!     let _ = client.base_object_list([], &mut list, init_object).await;
@@ -1113,11 +1113,11 @@ impl Client {
     ///     let mut bucket = MyBucket::default();
     ///
     ///     // 利用闭包对 MyFile 做一下初始化设置
-    ///     fn init_file(_list: &mut MyBucket) -> MyFile {
-    ///         MyFile {
+    ///     fn init_file(_list: &mut MyBucket) -> std::io::Result<MyFile> {
+    ///         Ok(MyFile {
     ///             key: String::default(),
     ///             other: "abc".to_string(),
-    ///         }
+    ///         })
     ///     }
     ///
     ///     client.base_object_list([], &mut bucket, init_file).await?;

--- a/src/object.rs
+++ b/src/object.rs
@@ -449,7 +449,7 @@ impl ObjectList<RcPointer> {
             .builder(Method::GET, bucket_url, resource)?
             .send_adjust_error()?;
 
-        list.decode(&response.text()?, init_object_with_list_rc)
+        list.decode(&response.text()?, ObjectList::<RcPointer>::init_object)
             .map_err(ExtractListError::from)?;
 
         Ok(list)
@@ -1312,7 +1312,7 @@ impl ClientRc {
         let response = self.builder(Method::GET, bucket_url, resource)?;
         let content = response.send_adjust_error()?;
 
-        list.decode(&content.text()?, init_object_with_list_rc)?;
+        list.decode(&content.text()?, ObjectList::<RcPointer>::init_object)?;
 
         list.set_client(Rc::new(self));
         list.set_search_query(query);

--- a/src/object.rs
+++ b/src/object.rs
@@ -1067,6 +1067,11 @@ impl Client {
     }
 
     /// # 可将 object 列表导出到外部类型（关注便捷性）
+    ///
+    /// 从 Client 中的默认 bucket 中获取，如需获取其他 bucket 的，可调用 `set_bucket` 更改后调用
+    ///
+    /// 也可以通过调用 `set_endpoint` 更改可用区
+    ///
     /// 可以参考下面示例，或者项目中的 `examples/custom.rs`
     /// ## 示例
     /// ```rust
@@ -1165,6 +1170,10 @@ impl Client {
     }
 
     /// # 可将 object 列表导出到外部类型（关注性能）
+    ///
+    /// 从 Client 中的默认 bucket 中获取，如需获取其他 bucket 的，可调用 `set_bucket` 更改后调用
+    ///
+    /// 也可以通过调用 `set_endpoint` 更改可用区
     pub async fn base_object_list2<List, Item, E: ListError, ItemErr: Error + 'static>(
         &self,
         query: &Query,

--- a/src/tests/object.rs
+++ b/src/tests/object.rs
@@ -95,7 +95,7 @@ fn object_list_get_object_list() {
     )
     .middleware(Rc::new(MyMiddleware {}));
 
-    let mut object_list = ObjectList::<RcPointer>::new(
+    let object_list = ObjectList::<RcPointer>::new(
         "abc.oss-cn-shanghai.aliyuncs.com".parse().unwrap(),
         Some("foo2/".parse().unwrap()),
         100,


### PR DESCRIPTION
当我们想要创建一个自定义的类型来存储 oss 上的文件时，我们有两种选择：

- 1. 利用内置的 `ObjectList` 的泛型参数来实现
- 2. 需要自定义一个存储文件列表的类型，然后让它实现 `RefineObjectList<Item>` 这个 trait

使用第一种方式，可以减少一部分工作量，开发者只需要关注单个文件的类型即可，内置的列表类型会自动实现查询，翻页等功能：
```rust
use aliyun_oss_client::{
    decode::RefineObject,
    object::{InitObject, Objects},
    types::object::{InvalidObjectDir, ObjectDir, ObjectPathInner},
    Client,
};
use dotenv::dotenv;

#[derive(Debug)]
enum MyObject<'a> {
    File(ObjectPathInner<'a>),
    Dir(ObjectDir<'a>),
}

impl RefineObject<InvalidObjectDir> for MyObject<'_> {
    fn set_key(&mut self, key: &str) -> Result<(), InvalidObjectDir> {
        *self = match key.parse() {
            Ok(file) => MyObject::File(file),
            _ => MyObject::Dir(key.parse()?),
        };
        Ok(())
    }
}

type MyList<'a> = Objects<MyObject<'a>>;

impl<'a> InitObject<MyObject<'a>> for MyList<'a> {
    fn init_object(&mut self) -> Option<MyObject<'a>> {
        Some(MyObject::File(ObjectPathInner::default()))
    }
}
```

在上面代码中，我们声明了一个 `MyObject` 类型的枚举类型，用于存储 OSS 返回的文件或目录的集合，接下来我们将使用 lib 内置的功能，从 OSS 上下载相应的数据：
```rust
#[tokio::main]
async fn main() {
    dotenv().ok();

    let client = Client::from_env().unwrap();

    let mut list = MyList::default();

    let _ = client.base_object_list([], &mut list).await;

    let _second = list.get_next_base().await;

    println!("list: {:?}", list.to_vec());
}
```

当我们希望自己实现文件列表类型时，可以参考这个例子：
```rust
use aliyun_oss_client::{
    decode::{RefineObject, RefineObjectList},
    object::{ExtractListError, InitObject},
    Client, DecodeListError,
};
use dotenv::dotenv;
use thiserror::Error;

#[derive(Debug)]
struct MyFile {
    key: String,
    #[allow(dead_code)]
    other: String,
}

impl RefineObject<MyError> for MyFile {
    fn set_key(&mut self, key: &str) -> Result<(), MyError> {
        self.key = key.to_string();
        Ok(())
    }
}

#[derive(Default, Debug)]
struct MyBucket {
    name: String,
    files: Vec<MyFile>,
}

impl RefineObjectList<MyFile, MyError> for MyBucket {
    fn set_name(&mut self, name: &str) -> Result<(), MyError> {
        self.name = name.to_string();
        Ok(())
    }
    fn set_list(&mut self, list: Vec<MyFile>) -> Result<(), MyError> {
        self.files = list;
        Ok(())
    }
}

#[derive(Debug, Error, DecodeListError)]
#[error("my error")]
struct MyError {}

async fn get_with_client() -> Result<(), ExtractListError> {
    dotenv().ok();

    let client = Client::from_env().unwrap();

    // 除了设置Default 外，还可以做更多设置
    let mut bucket = MyBucket {
        name: "abc".to_string(),
        files: Vec::with_capacity(20),
    };

    // 利用闭包对 MyFile 做一下初始化设置
    impl InitObject<MyFile> for MyBucket {
        fn init_object(&mut self) -> Option<MyFile> {
            Some(MyFile {
                key: String::default(),
                other: "abc".to_string(),
            })
        }
    }

    client.base_object_list([], &mut bucket).await?;

    println!("bucket: {:?}", bucket);

    Ok(())
}
```