### PR TITLE
fix: fix url set_path does not encode backslash bug.

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -271,8 +271,8 @@ impl ObjectInfo {
 mod tests {
     use super::Object;
     use crate::{
-        bucket::Bucket,
-        client::{init_client, Client},
+        bucket::{self, Bucket},
+        client::{self, init_client, Client},
         types::{EndPoint, ObjectQuery},
     };
 
@@ -334,5 +334,13 @@ mod tests {
         let second_list = first_list.next_list(&condition, &client).await.unwrap();
 
         println!("{:?}", second_list);
+    }
+
+    #[tokio::test]
+    async fn test_to_url() {
+        let bucket = Bucket::new("honglei123", EndPoint::CN_SHANGHAI);
+        let object = Object::new("abc\\efg.txt");
+        let url = object.to_url(&bucket).to_string();
+        assert!(url.contains("\\") || url.contains("%5C"));
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -135,7 +135,7 @@ impl Object {
 
     pub fn to_url(&self, bucket: &Bucket) -> Url {
         let mut url = bucket.to_url();
-        url.set_path(&self.path);
+        url.path_segments_mut().unwrap().push(&self.path);
         url
     }
 


### PR DESCRIPTION
由于`rust url`中存在将`'\'`转换成`'/'`的问题。所以当上传到`oss bucket`的`path`中包含`'\'`则会导致路径出错，并且`access key`验证失败的问题。
[rust url bug](https://github.com/servo/rust-url/issues/612)